### PR TITLE
moha_survey 7.x-1.0-dev

### DIFF
--- a/modules/moha_survey/moha_survey.admin.inc
+++ b/modules/moha_survey/moha_survey.admin.inc
@@ -979,6 +979,7 @@ function moha_survey_clone_form_submit($form, &$form_state) {
     // Save the node.
     node_save($node);
 
+    $form_state['node'] = $node;
     $form_state['redirect'] = 'admin/moha/survey/edit/'. $node->nid;
   }
   else {
@@ -1020,6 +1021,7 @@ function moha_survey_clone_form_submit($form, &$form_state) {
         $entity->save();
       }
 
+      $form_state['node'] = $node;
       $form_state['redirect'] = 'admin/moha/survey/edit/'. $node->nid;
     }
   }


### PR DESCRIPTION
return node in form state after moha_survey_clone_form_submit then other modules can extend it easily.